### PR TITLE
Collisions not expiring due to DateTime formatting and timezone discrepancies

### DIFF
--- a/mnsnitch/services/MnSnitchService.php
+++ b/mnsnitch/services/MnSnitchService.php
@@ -67,7 +67,8 @@ class MnSnitchService extends BaseApplicationComponent
 		$timeOut = craft()->config->get('serverPollInterval', 'mnnocollide') * 10;
 		$old = clone $now;
 		$old->sub(new DateInterval('PT'.$timeOut.'S'));
-		$x = MnSnitchRecord::model()->deleteAll('whenEntered<:when', array(':when'=>$old));
+		$oldDateString = DateTimeHelper::formatTimeForDb($old);
+		$x = MnSnitchRecord::model()->deleteAll('whenEntered<:when', array(':when'=>$oldDateString));
 	}
 
 	public function userData(array $collisionModels, $userId = null)
@@ -109,6 +110,6 @@ class MnSnitchService extends BaseApplicationComponent
 
 	private function _now($now)
 	{
-		return ($now ? $now : new DateTime());
+		return ($now ? $now : DateTimeHelper::currentUTCDateTime());
 	}
 }


### PR DESCRIPTION
Craft CMS (thankfully) stores all dates/times in the DB in the UTC timezone. The current `master` branch currently 1) expires collisions based on the Craft system timezone, and 2) does not actually pass a time to the `MnSnitchRecord::model()->deleteAll()` call, it only uses a `YYYY-mm-dd` formatted representation.

Passing a `\Craft\DateTime` object as a query binding causes `\Craft\DateTime::__toString()` to be called by the ORM, which returns the date in `YYYY-mm-dd` format. So collisions will not expire until the next day, since the time is not part of that string.

This patch uses the `DateTimeHelper::formatTimeForDb()` method to give us the proper DB engine formatted date/time string, in the UTC timezone.

Tested on `Craft CMS 2.6.2903`.