### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     }
   ],
   "require": {
+    "craftcms/cms": "^3.0.0-RC1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.