### PR TITLE
fix: casing on snitch namespace in assetbundles

### DIFF
--- a/src/assetbundles/snitch/SnitchAsset.php
+++ b/src/assetbundles/snitch/SnitchAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2019 Marion Newlevant
  */
 
-namespace marionnewlevant\snitch\assetbundles\Snitch;
+namespace marionnewlevant\snitch\assetbundles\snitch;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
the uppercase S prevents us from generating authoritative classmaps in composer because the namespace was invalid